### PR TITLE
Reward-system change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ While autonomous vehicles have the potential to greatly improve our daily lives,
 1. All players draw 5 white cards from their stack 
 2. Click the spinner to choose the first player who will be the Card Czar.
 3. The Card Czar then pull a black prompt card and reads it to the group 
-4. All other players then put 1 white response card face down in their slot.
+4. All other players then put 1 white response card face down in their slot. They reflects on what could go wrong with their reponse.
 5. The Card Czar then flips and reads each white card out loud.
-6. The Card Czar then picks one of the white cards to further discuss. +1 point goes to the player whose card was chosen.
-7. The group then discusses further what else could go wrong based on the chosen card. People can award +1 point anyone who makes a good point in discussion.
-8. After the discussion dissipates after a few minutes, the next player becomes the Card Czar and clicks the “Deal” button. Each player then draws a new white card, so that they again have 5 cards in their hand.
+6. The Card Czar then picks one of the white cards for further discussion. The player whose card was chosen becomes the Secretary for this round.As the Secretary, the selected player does not participate in the ensuing debate but listens carefully.
+7. After the discussion winds down (after a few minutes), the Secretary has 1 minute to summarize all the arguments made and present their own position based on the debate.
+8. The other players then vote on whether the Secretary has been convincing. If the majority finds the summary and position convincing, the Secretary earns 1 point.
+9. The next player becomes the Card Czar and clicks the “Deal” button. Each player then draws a new white card, so that they again have 5 cards in their hand.
 
 ### During the game
 1. Take notes on ideas that you have not thought about before


### PR DESCRIPTION
The "why" of this commit is detailed in the associated issue I have created. My suggestion is to get rid of the rule « +1 point goes to the player whose card was chosen » because it does not make sense rewarding it. This revision aims to encourage deeper engagement with the topics discussed and rewards players for actively listening, synthesizing arguments, and articulating a well-considered stance on the issue.